### PR TITLE
Correção erro de sintaxe em f-strings com padrão regex (Python 3.8+)

### DIFF
--- a/exemplo_uso.py
+++ b/exemplo_uso.py
@@ -16,7 +16,7 @@ def main():
     texto = "123abc456def"
     print(f"Texto: {texto}")
     print(f"Padrão: \\d+")
-    print(f"Resultado: {splitter.split(texto, r'\d+')}")
+    print("Resultado:", splitter.split(texto, r"\d+"))
     print()
     
     print("Exemplo 2: Divisão por vogais repetidas")
@@ -37,7 +37,7 @@ def main():
     texto = "a1b22c333d4444e"
     print(f"Texto: {texto}")
     print(f"Padrão: \\d+")
-    print(f"Resultado: {splitter.split(texto, r'\d+')}")
+    print("Resultado:", splitter.split(texto, r"\d+"))
 
 if __name__ == "__main__":
     main() 


### PR DESCRIPTION
Este PR corrige um erro de sintaxe causado pelo uso de uma expressão com barra invertida (\d+) dentro de uma f-string, o que gera SyntaxError em versões do Python 3.8 ou superiores.

Alterações realizadas:
Substituição de chamadas como f"Resultado: {splitter.split(texto, r'\d+')}" por print("Resultado:", splitter.split(...)), evitando o uso de expressões com barra invertida dentro de f-strings.

Garantia de compatibilidade com Python 3.8+.

Referência do erro:
SyntaxError: f-string expression part cannot include a backslash
<img width="691" height="117" alt="image" src="https://github.com/user-attachments/assets/faa0ac35-fb52-422b-9c6d-5e58e21a3ade" />


Testado em:
Python 3.10.12

Observações:
Essa correção não altera a lógica do CustomSplitter, apenas a forma como os padrões são impressos no terminal.
